### PR TITLE
Preserve item spawning data supported by v5 and v6 setup files

### DIFF
--- a/Super Paper Mario Randomizer/Common/SPM.cs
+++ b/Super Paper Mario Randomizer/Common/SPM.cs
@@ -41,6 +41,7 @@ namespace Super_Paper_Mario_Randomizer
 
         public byte[] Header { get; set; }
         public List<LevelSetupEntryEntry> Entries { get; set; }
+        public byte[] Footer { get; set; }
 
         public LevelSetupEntry(string _FilePath)
         {
@@ -50,6 +51,7 @@ namespace Super_Paper_Mario_Randomizer
 
             Header = ByteOps.GetNumBytes(4, 0, FilePath);
             Entries = LevelSetupEntryEntry.GetListOfEntriesFromData(File.ReadAllBytes(FilePath).Skip(4).ToArray(), Header);
+            Footer = File.ReadAllBytes(FilePath).Skip(4 + (100 * (int)SPMDefs.EntrySizes[(SPMDefs.HeaderSize)Header[1]])).ToArray();
         }
 
         public override string ToString()
@@ -68,6 +70,8 @@ namespace Super_Paper_Mario_Randomizer
 
             foreach (LevelSetupEntryEntry Entry in this.Entries)
                 Out.AddRange(Entry.ToBytes(this.Header));
+
+            Out.AddRange(this.Footer);
 
             return Out.ToArray();
         }
@@ -157,7 +161,7 @@ namespace Super_Paper_Mario_Randomizer
 
             int EntrySize = (int)SPMDefs.EntrySizes[(SPMDefs.HeaderSize)Header[1]];
 
-            while (Pos + EntrySize <= Data.Length)
+            for (int i = 0; i < 100; i++)
             {
                 byte[] Entry = Data.Skip(Pos).Take(EntrySize).ToArray();
                 Outl.Add(new LevelSetupEntryEntry(Entry, Header));


### PR DESCRIPTION
If you open a setup folder with the vanilla files, make no changes to any, save all and then compare them to the originals, you'll see the following 14 files are different:
- an3_01.dat
- an3_03.dat
- an3_12.dat
- an3_14.dat
- an3_15.dat
- an4_12.dat
- gn3_04.dat
- he1_03.dat
- he2_08.dat
- mi1_10.dat
- sp2_09.dat
- sp4_15.dat
- ta2_01.dat
- ta2_02.dat

This is because setup files have support for spawning items - which I documented a bit [here](https://github.com/SeekyCt/spm-docs/blob/master/setup_data.h) - and these files use that, while the tool currently just reads it as enemy data.

This pull request makes it so that any data after the list of enemy entries (which I found the game's code expects there to be exactly 100 of) is stored into a separate footer array and appended to the file exactly how it was when saving, so all of the item information is preserved. Opening the vanilla folder and saving all now gives 1:1 identical files for every map and edited files should still correctly preserve the item information.